### PR TITLE
make webpack look for .tsx extensions (for typescript jsx projects)

### DIFF
--- a/packages/electron-webpack/src/configurators/ts.ts
+++ b/packages/electron-webpack/src/configurators/ts.ts
@@ -9,7 +9,7 @@ export async function configureTypescript(configurator: WebpackConfigurator) {
   }
 
   // add after js
-  configurator.extensions.splice(1, 0, ".ts")
+  configurator.extensions.splice(1, 0, ".ts", ".tsx")
 
   const isTranspileOnly = configurator.isTest || (hasTsChecker && !configurator.isProduction)
 


### PR DESCRIPTION
TypeScript convention seems to prefer omitting the file extension

    import Widget from './Widget';

Despite TypeScript being happy with this it seems the webpack configuration does not indicate to try finding the module under the `.tsx` extension and complains that it could not find the referenced module.

This seems to solve the issue for me.