### PR TITLE
Including custom env variables in the build

### DIFF
--- a/packages/electron-webpack/src/targets/BaseTarget.ts
+++ b/packages/electron-webpack/src/targets/BaseTarget.ts
@@ -86,8 +86,8 @@ export class BaseTarget {
     }
 
     plugins.push(new NoEmitOnErrorsPlugin())
-    
-    const additionalEnvironmentVariables = Object.keys(process.env).filter(key => /^ELECTRON_WEBPACK_APP_.+$/.test(key));
+
+    const additionalEnvironmentVariables = Object.keys(process.env).filter(key => /^ELECTRON_WEBPACK_APP_.+$/.test(key))
     if (additionalEnvironmentVariables.length) {
       plugins.push(new EnvironmentPlugin(additionalEnvironmentVariables))
     }

--- a/packages/electron-webpack/src/targets/BaseTarget.ts
+++ b/packages/electron-webpack/src/targets/BaseTarget.ts
@@ -1,5 +1,5 @@
 import * as path from "path"
-import { DefinePlugin, HotModuleReplacementPlugin, LoaderOptionsPlugin, NamedModulesPlugin, NoEmitOnErrorsPlugin, Rule, optimize } from "webpack"
+import { DefinePlugin, HotModuleReplacementPlugin, LoaderOptionsPlugin, NamedModulesPlugin, NoEmitOnErrorsPlugin, EnvironmentPlugin, Rule, optimize } from "webpack"
 import { configureDll } from "../configurators/dll"
 import { createBabelLoader } from "../configurators/js"
 import { WebpackConfigurator } from "../main"
@@ -86,6 +86,11 @@ export class BaseTarget {
     }
 
     plugins.push(new NoEmitOnErrorsPlugin())
+    
+    const additionalEnvironmentVariables = Object.keys(process.env).filter(key => /^ELECTRON_WEBPACK_APP_.+$/.test(key));
+    if (additionalEnvironmentVariables.length) {
+      plugins.push(new EnvironmentPlugin(additionalEnvironmentVariables))
+    }
   }
 }
 

--- a/packages/electron-webpack/src/targets/BaseTarget.ts
+++ b/packages/electron-webpack/src/targets/BaseTarget.ts
@@ -87,8 +87,8 @@ export class BaseTarget {
 
     plugins.push(new NoEmitOnErrorsPlugin())
 
-    const additionalEnvironmentVariables = Object.keys(process.env).filter(key => /^ELECTRON_WEBPACK_APP_.+$/.test(key))
-    if (additionalEnvironmentVariables.length) {
+    const additionalEnvironmentVariables = Object.keys(process.env).filter(it => it.startsWith("ELECTRON_WEBPACK_APP_"))
+    if (additionalEnvironmentVariables.length > 0) {
       plugins.push(new EnvironmentPlugin(additionalEnvironmentVariables))
     }
   }


### PR DESCRIPTION
Hi, thanks for this awesome project!

For my use case I needed to include custom environment variable in the bundle during build time.
With this fork any process variable that starts with `ELECTRON_WEBPACK_APP_` (for eg. `ELECTRON_WEBPACK_APP_API_URL`, `ELECTRON_WEBPACK_APP_CLIENT_NAME`, etc.) will be bundled using `EnvironmentPlugin` on both main and renderer targets.