### PR TITLE
support user-defined babel presets and plugins, add HMR for stylesheets

### DIFF
--- a/packages/electron-webpack/package.json
+++ b/packages/electron-webpack/package.json
@@ -26,6 +26,7 @@
     "bluebird-lst": "^1.0.3",
     "chalk": "^2.1.0",
     "crocket": "^0.9.11",
+    "css-hot-loader": "^1.3.1",
     "css-loader": "^0.28.7",
     "debug": "^3.0.1",
     "electron-devtools-installer": "^2.2.0",

--- a/packages/electron-webpack/src/configurators/js.ts
+++ b/packages/electron-webpack/src/configurators/js.ts
@@ -10,17 +10,21 @@ export function createBabelLoader(configurator: WebpackConfigurator) {
       targets: computeBabelEnvTarget(configurator.isRenderer, configurator.electronVersion),
     }],
   ]
+  const plugins = [
+      require("babel-plugin-syntax-dynamic-import"),
+  ]
 
   const userPresets = configurator.getMatchingDevDependencies('babel-preset-', {not: ['babel-preset-env']});
   userPresets.forEach(preset => presets.push([require(preset)]));
+
+  const userPlugins = configurator.getMatchingDevDependencies('babel-plugin-', {not: ['babel-plugin-syntax-dynamic-import']});
+  userPlugins.forEach(plugin => plugins.push([require(plugin)]));
 
   return {
     loader: "babel-loader",
     options: {
       presets,
-      plugins: [
-        require("babel-plugin-syntax-dynamic-import"),
-      ]
+      plugins
     }
   }
 }

--- a/packages/electron-webpack/src/configurators/js.ts
+++ b/packages/electron-webpack/src/configurators/js.ts
@@ -15,10 +15,16 @@ export function createBabelLoader(configurator: WebpackConfigurator) {
   ]
 
   const userPresets = configurator.getMatchingDevDependencies('babel-preset-', {not: ['babel-preset-env']});
-  userPresets.forEach(preset => presets.push([require(preset)]));
+  userPresets.forEach(preset => {
+      const presetModule = require(preset);
+      presets.push([presetModule.default || presetModule])
+  });
 
   const userPlugins = configurator.getMatchingDevDependencies('babel-plugin-', {not: ['babel-plugin-syntax-dynamic-import']});
-  userPlugins.forEach(plugin => plugins.push([require(plugin)]));
+  userPlugins.forEach(plugin => {
+      const pluginModule = require(plugin);
+      plugins.push([pluginModule.default || pluginModule])
+  });
 
   return {
     loader: "babel-loader",

--- a/packages/electron-webpack/src/configurators/js.ts
+++ b/packages/electron-webpack/src/configurators/js.ts
@@ -11,9 +11,8 @@ export function createBabelLoader(configurator: WebpackConfigurator) {
     }],
   ]
 
-  if (configurator.hasDevDependency("babel-preset-react")) {
-    presets.push([require("babel-preset-react")])
-  }
+  const userPresets = configurator.getMatchingDevDependencies('babel-preset-', {not: ['babel-preset-env']});
+  userPresets.forEach(preset => presets.push([require(preset)]));
 
   return {
     loader: "babel-loader",

--- a/packages/electron-webpack/src/main.ts
+++ b/packages/electron-webpack/src/main.ts
@@ -138,6 +138,27 @@ export class WebpackConfigurator {
     return name in this.metadata.devDependencies
   }
 
+  /**
+   * Returns the names of devDependencies that match a given string or regex.
+   * If no matching dependecies are found, an empty array is returned.
+   *
+   * @param {string|regex} name - The matcher term, e.g. `babel-preset-`
+   * @param {object} options - optional configuration
+   * @param {array} options.not - list of matchers to exclude, e.g. `{not: ['babel-preset-env']}`
+   * @return {array} - list of matching dependency names, e.g. `['babel-preset-react', 'babel-preset-stage-0']`
+   */
+  getMatchingDevDependencies(name, options) {
+      const excludes = options && options.not || [];
+      return Object.keys(this.metadata.devDependencies).reduce((result, key) => {
+          const isExclude = excludes.some(excludedKey => name.match(excludedKey));
+          const isMatch = key.match(name) && !isExclude;
+          if (isMatch) {
+              result.push(key);
+          }
+          return result;
+      }, []);
+  }
+
   async configure(entry?: { [key: string]: any } | null) {
     this.config = {
       context: this.projectDir,

--- a/packages/electron-webpack/src/targets/RendererTarget.ts
+++ b/packages/electron-webpack/src/targets/RendererTarget.ts
@@ -21,7 +21,7 @@ export class BaseRendererTarget extends BaseTarget {
 
     configurator.extensions.push(".css")
 
-    const cssHotLoader = configurator.isProduction ? ['css-hot-loader'] : []
+    const cssHotLoader = configurator.isProduction ? [] : ['css-hot-loader']
 
     function configureFileLoader(prefix: string) {
       return {

--- a/packages/electron-webpack/src/targets/RendererTarget.ts
+++ b/packages/electron-webpack/src/targets/RendererTarget.ts
@@ -21,6 +21,8 @@ export class BaseRendererTarget extends BaseTarget {
 
     configurator.extensions.push(".css")
 
+    const cssHotLoader = configurator.isProduction ? ['css-hot-loader'] : []
+
     function configureFileLoader(prefix: string) {
       return {
         limit: 10000,
@@ -31,30 +33,30 @@ export class BaseRendererTarget extends BaseTarget {
     configurator.rules.push(
       {
         test: /\.css$/,
-        use: ExtractTextPlugin.extract({
+        use: cssHotLoader.concat(ExtractTextPlugin.extract({
           use: "css-loader",
           fallback: "style-loader",
-        }),
+        })),
       },
       {
         test: /\.less$/,
-        use: ExtractTextPlugin.extract({
+        use: cssHotLoader.concat(ExtractTextPlugin.extract({
           use: [
             {loader: "css-loader"},
             {loader: "less-loader"}
           ],
           fallback: "style-loader"
-        })
+        }))
       },
       {
         test: /\.scss/,
-        use: ExtractTextPlugin.extract({
+        use: cssHotLoader.concat(ExtractTextPlugin.extract({
           use: [
             {loader: "css-loader"},
             {loader: "sass-loader"}
           ],
           fallback: "style-loader"
-        })
+        }))
       },
       {
         test: /\.(png|jpe?g|gif|svg)(\?.*)?$/,


### PR DESCRIPTION
### support user-defined babel presets and plugins

This change will add any babel preset or plugin found in the user's devDependencies to the internal babel configuration.

Rather than only specifically supporting `babel-preset-react`, this change allows users to add any babel preset or plugin to their project, like `babel-preset-stage-0`, or `babel-plugin-transform-decorators-legacy`

---

### support HMR for stylesheets

_I don't know how to avoid further commits in my fork landing inside this PR. So now the PR adds another feature_

This change adds hot module replacement for stylesheets (css,less,scss) in development mode by using `css-hot-loader` before `extract-text-webpack-plugin`.
