### PR TITLE
Allow passing CLI arguments to the application in `dev` mode

### DIFF
--- a/packages/electron-webpack/src/dev/dev-runner.ts
+++ b/packages/electron-webpack/src/dev/dev-runner.ts
@@ -56,6 +56,8 @@ class DevRunner {
     const electronArgs = process.env.ELECTRON_ARGS
     const args = electronArgs != null && electronArgs.length > 0 ? JSON.parse(electronArgs) : [`--inspect=${await getFreePort("127.0.0.1", 5858)}`]
     args.push(path.join(projectDir, "dist/main/main.js"))
+    // Pass remaining arguments to the application. Remove 3 instead of 2, to remove the `dev` argument as well.
+    args.push(...process.argv.slice(3))
     // we should start only when both start and main are started
     startElectron(args, env)
   }


### PR DESCRIPTION
I needed to pass arguments to my application, which was not possible in `dev` mode. See also: https://github.com/electron-userland/electron-webpack/issues/73

Now it should be possible in dev and prod mode as well:

- DEV: `yarn dev --arg=1 --arg2`
- PROD: `my.app --args --arg=1 --arg2`