### PR TITLE
fix "Modules not found" #120

### DIFF
--- a/packages/electron-webpack/src/targets/RendererTarget.ts
+++ b/packages/electron-webpack/src/targets/RendererTarget.ts
@@ -179,13 +179,16 @@ async function generateIndexFile(configurator: WebpackConfigurator, nodeModulePa
 
   const title = await computeTitle(configurator)
   const filePath = path.join(configurator.commonDistDirectory, ".renderer-index-template.html")
+  
+  nodeModulePath = nodeModulePath.replace(/\\/g, "\\\\")
+  
   await outputFile(filePath, `<!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8">
     ${title == null ? "" : `<title>${title}</title>`}
     <script>
-      ${nodeModulePath == null ? "" : `require("module").globalPaths.push('${nodeModulePath.replace(/\\/g, "\\\\")}')`}
+      ${nodeModulePath == null ? "" : `require("module").globalPaths.push("${nodeModulePath.replace(/\\/g, "\\\\")}")`}
       require("source-map-support/source-map-support.js").install()
     </script>
     ${scripts.join("")}

--- a/packages/electron-webpack/src/targets/RendererTarget.ts
+++ b/packages/electron-webpack/src/targets/RendererTarget.ts
@@ -185,7 +185,7 @@ async function generateIndexFile(configurator: WebpackConfigurator, nodeModulePa
     <meta charset="utf-8">
     ${title == null ? "" : `<title>${title}</title>`}
     <script>
-      ${nodeModulePath == null ? "" : `require("module").globalPaths.push("${nodeModulePath.replace(/\\/g, "\\\\")}")`}
+      ${nodeModulePath == null ? "" : `require("module").globalPaths.push('${nodeModulePath.replace(/\\/g, "\\\\")}')`}
       require("source-map-support/source-map-support.js").install()
     </script>
     ${scripts.join("")}


### PR DESCRIPTION
currently on Windows, the path 
`"C:\git\electron-webpack-quick-start\node_modules"`
change to 
`C:gitelectron-webpack-quick-start↵ode_modules`

so need do replace once before html write.
`nodeModulePath = nodeModulePath.replace(/\\/g, "\\\\")`

but only tested on Windows, maybe need check platform first