### PR TITLE
Fix element-ui plugin loading

### DIFF
--- a/packages/electron-webpack/src/configurators/js.ts
+++ b/packages/electron-webpack/src/configurators/js.ts
@@ -15,12 +15,10 @@ export function createBabelLoader(configurator: WebpackConfigurator) {
   ]
 
   if (configurator.type !== "main" && configurator.hasDependency("element-ui")) {
-    plugins.push([require("babel-plugin-component"), [
-      {
-        libraryName: "element-ui",
-        styleLibraryName: "theme-chalk"
-      },
-    ]])
+    plugins.push([require("babel-plugin-component"), {
+      libraryName: "element-ui",
+      styleLibraryName: "theme-chalk"
+    }])
   }
 
   addBabelItem(presets, configurator.getMatchingDevDependencies({includes: ["babel-preset-"], excludes: ["babel-preset-env", "@babel/preset-env"]}))


### PR DESCRIPTION
Hello. I got an error when I tried to use electron-webpack with element-ui, so I'd like to report it and open PR.

### Description
electron-webpack fails to compile an app if I just add element-ui to dependencies.

* Node v8.11.2
* electron-webpack 2.1.1

```shell
# Copy template following quick start guide
 % git clone https://github.com/electron-userland/electron-webpack-quick-start.git
 % cd electron-webpack-quick-start
 % rm -rf .git
 % yarn

# Add element-ui to dependencies and compile an app
 % yarn add element-ui
 % yarn compile
yarn run v1.6.0
$ electron-webpack
  0% [0] Hash: 40db88439b16683b2e04d7fc0b129a3d43cce2be
Version: webpack 4.8.1
Child
    Hash: 40db88439b16683b2e04
    Time: 1111ms
    Built at: 2018-05-23 14:29:42
          Asset      Size  Chunks             Chunk Names
        main.js  1.37 KiB       0  [emitted]  main
    main.js.map  2.24 KiB       0  [emitted]  main
    Entrypoint main = main.js main.js.map
    [0] external "electron" 42 bytes {0} [built]
    [1] external "url" 42 bytes {0} [built]
    [2] external "path" 42 bytes {0} [built]
    [3] ./src/main/index.js 1.42 KiB {0} [built]
    [4] multi ./src/main/index.js 28 bytes {0} [built]
Child
    Hash: d7fc0b129a3d43cce2be
    Time: 837ms
    Built at: 2018-05-23 14:29:42
     2 assets
    Entrypoint renderer = renderer.js renderer.js.map
    [0] ./src/renderer/index.js 1.41 KiB {0} [built] [failed] [1 error]
    [1] multi ./src/renderer/index.js 28 bytes {0} [built]

    ERROR in ./src/renderer/index.js
    Module build failed: Error: .plugins[1][1] must be an object, false, or undefined
        at assertPluginItem (/Users/yahatakeiji/work/oimou/electron-webpack-quick-start/node_modules/@babel/core/lib/config/validation/option-assertions.js:159:15)
        at /Users/yahatakeiji/work/oimou/electron-webpack-quick-start/node_modules/@babel/core/lib/config/validation/option-assertions.js:136:14
        at Array.forEach (<anonymous>)
        at assertPluginList (/Users/yahatakeiji/work/oimou/electron-webpack-quick-start/node_modules/@babel/core/lib/config/validation/option-assertions.js:135:9)
        at /Users/yahatakeiji/work/oimou/electron-webpack-quick-start/node_modules/@babel/core/lib/config/validation/options.js:86:20
        at Array.forEach (<anonymous>)
        at validate (/Users/yahatakeiji/work/oimou/electron-webpack-quick-start/node_modules/@babel/core/lib/config/validation/options.js:64:21)
        at loadPrivatePartialConfig (/Users/yahatakeiji/work/oimou/electron-webpack-quick-start/node_modules/@babel/core/lib/config/partial.js:38:48)
        at loadFullConfig (/Users/yahatakeiji/work/oimou/electron-webpack-quick-start/node_modules/@babel/core/lib/config/full.js:43:37)
        at /Users/yahatakeiji/work/oimou/electron-webpack-quick-start/node_modules/@babel/core/lib/transform.js:28:33
        at _combinedTickCallback (internal/process/next_tick.js:131:7)
        at process._tickCallback (internal/process/next_tick.js:180:9)
     @ multi ./src/renderer/index.js
    Child html-webpack-plugin for "index.html":
         1 asset
        Entrypoint undefined = index.html
        [0] ./node_modules/html-loader/dist/cjs.js?minimize=false!./dist/.renderer-index-template.html 260 bytes {0} [built]
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

### Why this error occurs
First, electron-webpack does dedicated process to element-ui: electron-webpack adds an additional babel-loader plugin as `[ plugin, [ option ] ]` if element-ui is in dependencies.
https://github.com/electron-userland/electron-webpack/blob/master/packages/electron-webpack/src/configurators/js.ts#L18

On the other hand, Babel expects a plugin to be `[ plugin, option ]`.

Therefore, just adding element-ui to dependencies causes the error of Babel.