### PR TITLE
Accept scoped babel package names

### DIFF
--- a/packages/electron-webpack/src/configurators/js.ts
+++ b/packages/electron-webpack/src/configurators/js.ts
@@ -21,8 +21,8 @@ export function createBabelLoader(configurator: WebpackConfigurator) {
     }])
   }
 
-  addBabelItem(presets, configurator.getMatchingDevDependencies({includes: ["babel-preset-"], excludes: ["babel-preset-env", "@babel/preset-env"]}))
-  addBabelItem(plugins, configurator.getMatchingDevDependencies({includes: ["babel-plugin-"], excludes: ["babel-plugin-syntax-dynamic-import"]}))
+  addBabelItem(presets, configurator.getMatchingDevDependencies({includes: ["babel-preset-", "@babel/preset-"], excludes: ["babel-preset-env", "@babel/preset-env"]}))
+  addBabelItem(plugins, configurator.getMatchingDevDependencies({includes: ["babel-plugin-", "@babel/plugin-"], excludes: ["babel-plugin-syntax-dynamic-import"]}))
 
   return {
     loader: "babel-loader",

--- a/packages/electron-webpack/src/main.ts
+++ b/packages/electron-webpack/src/main.ts
@@ -155,7 +155,7 @@ export class WebpackConfigurator {
    * Returns the names of devDependencies that match a given string or regex.
    * If no matching dependencies are found, an empty array is returned.
    *
-   * @return list of matching dependency names, e.g. `['babel-preset-react', 'babel-preset-stage-0']`
+   * @return list of matching dependency names, e.g. `['@babel/preset-react', '@babel/preset-stage-0']`
    */
   getMatchingDevDependencies(options: GetMatchingDevDependenciesOptions = {}) {
     const includes = options.includes || []

--- a/test/src/loaderDetectionTest.ts
+++ b/test/src/loaderDetectionTest.ts
@@ -42,7 +42,7 @@ test("react", async () => {
   await writeJson(path.join(projectDir, "package.json"), {
     name: "Test",
     devDependencies: {
-      "babel-preset-react": "*"
+      "@babel/preset-react": "*"
     }
   })
   await writeFile(path.join(projectDir, "src/renderer/file.jsx"), `


### PR DESCRIPTION
electron-webpack currently only accept old non-scoped babel package names like `babel-preset-react`. This PR adds new scoped package names like `@babel/preset-react`.

Maybe this is related to #60 