### PR TITLE
[PR] fix: custom typescript loaders (#147) (#158)

### DIFF
--- a/packages/electron-webpack/src/configurators/ts.ts
+++ b/packages/electron-webpack/src/configurators/ts.ts
@@ -3,13 +3,16 @@ import { WebpackConfigurator } from "../main"
 import { getFirstExistingFile } from "../util"
 
 export async function configureTypescript(configurator: WebpackConfigurator) {
-  const hasTsChecker = configurator.hasDevDependency("fork-ts-checker-webpack-plugin") || configurator.hasDevDependency("electron-webpack-ts")
-  if (!(hasTsChecker || configurator.hasDevDependency("ts-loader"))) {
+  const hasTsChecker = configurator.hasDevDependency("fork-ts-checker-webpack-plugin")
+  const hasTsLoader = configurator.hasDevDependency("ts-loader")
+  
+  // add after js
+  configurator.extensions.splice(1, 0, ".ts", ".tsx")
+  
+  if (!(hasTsChecker && hasTsLoader) && !configurator.hasDevDependency("electron-webpack-ts")) {
     return
   }
 
-  // add after js
-  configurator.extensions.splice(1, 0, ".ts", ".tsx")
 
   const isTranspileOnly = configurator.isTest || (hasTsChecker && !configurator.isProduction)
 


### PR DESCRIPTION
Other users like myself prefer to use different loaders than the currently configured ones.

This pull request allows the user to decide whether to use the default `ts-loader` - `fork-ts-checker-webpack-plugin` combo, or a custom config. 

To load the default, it will require that either:

* `ts-loader` **_and_** `fork-ts-checker-webpack-plugin` are devDependencies of the project
* or `electron-webpack-ts` is a devDependency

If none of those conditions are met, then it will merge the plugins added by the user.