### PR TITLE
[WIP] Add support for a custom dist directory

### DIFF
--- a/packages/electron-webpack/src/core.ts
+++ b/packages/electron-webpack/src/core.ts
@@ -16,6 +16,7 @@ export interface ElectronWebpackConfiguration {
   main?: ElectronWebpackConfigurationMain | null
 
   commonSourceDirectory?: string | null
+  commonDistDirectory?: string | null
 
   title?: string | boolean | null
 

--- a/packages/electron-webpack/src/main.ts
+++ b/packages/electron-webpack/src/main.ts
@@ -59,6 +59,7 @@ export class WebpackConfigurator {
 
   readonly sourceDir: string
   readonly commonSourceDirectory: string
+  readonly commonDistDirectory: string
 
   readonly debug = _debug(`electron-webpack:${this.type}`)
 
@@ -109,6 +110,8 @@ export class WebpackConfigurator {
 
     const commonSourceDirectory = this.electronWebpackConfiguration.commonSourceDirectory
     this.commonSourceDirectory = commonSourceDirectory == null ? path.join(this.projectDir, "src", "common") : path.resolve(this.projectDir, commonSourceDirectory)
+
+    this.commonDistDirectory = path.resolve(this.projectDir, this.electronWebpackConfiguration.commonDistDirectory || "dist")
   }
 
   /**
@@ -137,10 +140,6 @@ export class WebpackConfigurator {
     else {
       return this.electronWebpackConfiguration.renderer
     }
-  }
-
-  get commonDistDirectory() {
-    return path.join(this.projectDir, "dist")
   }
 
   hasDependency(name: string) {


### PR DESCRIPTION
This adds support for a custom dist directory as asked in #203 

This is especially useful when using the custom directories.app property in electron-builder. Without having the possibly of changing the output directory of electron-webpack it is also not possible to change the directories.app, since the build of electron-builder will simply just fail.