### PR TITLE
fix: allow users to run electron-webpack outside a workspace root

### DIFF
--- a/packages/electron-webpack/src/cli.ts
+++ b/packages/electron-webpack/src/cli.ts
@@ -28,7 +28,7 @@ function build(configFile: string) {
   args.push("--config", path.join(__dirname, "..", `webpack.${configFile}.config.js`))
 
   require("yargs")(args.slice(2))
-  require(path.join(process.cwd(), "node_modules", "webpack-cli", "bin", "cli.js"))
+  require(require.resolve("webpack-cli"))
 }
 
 function runInDevMode() {

--- a/packages/electron-webpack/src/dev/WebpackDevServerManager.ts
+++ b/packages/electron-webpack/src/dev/WebpackDevServerManager.ts
@@ -9,8 +9,7 @@ import { LineFilter, logError, logProcess, logProcessErrorOutput } from "./devUt
 const debug = require("debug")("electron-webpack")
 
 function runWds(projectDir: string, env: any) {
-  const isWin = process.platform === "win32"
-  const webpackDevServerPath = path.join(projectDir, "node_modules", ".bin", "webpack-dev-server" + (isWin ? ".cmd" : ""))
+  const webpackDevServerPath = require.resolve(path.join("webpack-dev-server", "bin", "webpack-dev-server.js"))
   debug(`Start renderer WDS ${webpackDevServerPath} on ${env.ELECTRON_WEBPACK_WDS_PORT} port`)
   return run(webpackDevServerPath, ["--color", "--env.autoClean=false", "--config", path.join(__dirname, "../../webpack.renderer.config.js")], {
     env,

--- a/packages/electron-webpack/src/targets/RendererTarget.ts
+++ b/packages/electron-webpack/src/targets/RendererTarget.ts
@@ -106,7 +106,7 @@ export class RendererTarget extends BaseRendererTarget {
     // not configurable for now, as in the electron-vue
     const customTemplateFile = path.join(configurator.projectDir, "src/index.ejs")
     const HtmlWebpackPlugin = require("html-webpack-plugin")
-    const nodeModulePath = configurator.isProduction ? null : path.resolve(configurator.projectDir, "node_modules")
+    const nodeModulePath = configurator.isProduction ? null : path.resolve(require.resolve('electron'), '..', '..')
 
     configurator.plugins.push(new HtmlWebpackPlugin({
       filename: "index.html",


### PR DESCRIPTION
This PR has ~two~ three small changes allowing us to run `electron-webpack` in a directory other than the workspace root. Our monorepo uses [Yarn workspaces](https://yarnpkg.com/lang/en/docs/workspaces/), and we want to support `electron-webpack` project(s) without overloading the root workspace private package.

By using `require.resolve`, we don't have to make assumptions about where the `node_modules` directory is.