### PR TITLE
Fixes to things that stopped working after commit c4cf41158b8b3a763d4254980f417d74531c7ade

### DIFF
--- a/packages/electron-webpack/src/config.ts
+++ b/packages/electron-webpack/src/config.ts
@@ -6,19 +6,16 @@ import { getConfig } from "read-config-file"
 
 export { ElectronWebpackConfiguration } from "./core"
 
-export async function getPackageMetadata() {
-  const projectDir = process.cwd()
-  return await orNullIfFileNotExist(readJson(path.join(projectDir, "package.json")))
+export async function getPackageMetadata(projectDir?: string | null) {
+  return await orNullIfFileNotExist(readJson(path.join(projectDir || process.cwd(), "package.json")))
 }
 
-export async function getElectronWebpackConfig() {
-  const projectDir = process.cwd()
-  const packageMetadata = await getPackageMetadata()
-  const electronWebpackConfig = ((await getConfig({
+export async function getElectronWebpackConfig(projectDir?: string | null) {
+  const packageMetadata = await getPackageMetadata(projectDir)
+  return ((await getConfig({
     packageKey: "electronWebpack",
     configFilename: "electron-webpack",
-    projectDir,
+    projectDir: projectDir || process.cwd(),
     packageMetadata: new Lazy(() => Promise.resolve(packageMetadata))
   })) || {} as any).result || {}
-  return electronWebpackConfig
 }

--- a/packages/electron-webpack/src/dev/dev-runner.ts
+++ b/packages/electron-webpack/src/dev/dev-runner.ts
@@ -21,7 +21,7 @@ const debug = require("debug")("electron-webpack")
 // do not remove main.js to allow IDE to keep breakpoints
 async function emptyMainOutput() {
   const electronWebpackConfig = await getElectronWebpackConfig()
-  const outDir = path.join(projectDir, electronWebpackConfig.commonDistDirectory, "main")
+  const outDir = path.join(projectDir, electronWebpackConfig.commonDistDirectory || "dist", "main")
   const files = await orNullIfFileNotExist(readdir(outDir))
   if (files == null) {
     return

--- a/packages/electron-webpack/src/main.ts
+++ b/packages/electron-webpack/src/main.ts
@@ -304,8 +304,8 @@ export async function createConfigurator(type: ConfigurationType, env: Configura
   if (env == null) {
      env = {}
    }
-
-  const electronWebpackConfig = await getElectronWebpackConfig()
+  const projectDir = (env.configuration || {}).projectDir
+  const electronWebpackConfig = await getElectronWebpackConfig(projectDir)
   if (env.configuration != null) {
     deepAssign(electronWebpackConfig, env.configuration)
   }
@@ -320,7 +320,7 @@ How to fix:
   * Found? Check that the option in the appropriate place. e.g. "sourceDirectory" only in the "main" or "renderer", not in the root.
 `
   })
-  const packageMetadata = await getPackageMetadata()
+  const packageMetadata = await getPackageMetadata(projectDir)
   return new WebpackConfigurator(type, env, electronWebpackConfig, packageMetadata)
 }
 


### PR DESCRIPTION
projectDir was not being set based on what was passed from the test resulting in wrong package metadata