### PR TITLE
fix dev on Windows CreateProcess failed with error 193 (no message av…

### DIFF
--- a/packages/electron-webpack/src/dev/WebpackDevServerManager.ts
+++ b/packages/electron-webpack/src/dev/WebpackDevServerManager.ts
@@ -9,7 +9,8 @@ import { LineFilter, logError, logProcess, logProcessErrorOutput } from "./devUt
 const debug = require("debug")("electron-webpack")
 
 function runWds(projectDir: string, env: any) {
-  const webpackDevServerPath = require.resolve(path.join("webpack-dev-server", "bin", "webpack-dev-server.js"))
+  const isWin = process.platform === "win32";
+  const webpackDevServerPath = require.resolve(path.join(".bin", "webpack-dev-server" + (isWin ? ".cmd" : "")));
   debug(`Start renderer WDS ${webpackDevServerPath} on ${env.ELECTRON_WEBPACK_WDS_PORT} port`)
   return run(webpackDevServerPath, ["--color", "--env.autoClean=false", "--config", path.join(__dirname, "../../webpack.renderer.config.js")], {
     env,


### PR DESCRIPTION
Close #223

The bug seems to have been introduced with #219 . The webpack dev server still needs to be started with the .cmd in the .bin directory of node_modules, since node.exe is used there. runnerw.exe that would start the child process without this fix has problems with starting the webpack-dev-server.js directly.