### PR TITLE
fix: resolve custom commonSourceDir before setting up watch plugin

### DIFF
--- a/packages/electron-webpack/src/targets/BaseTarget.ts
+++ b/packages/electron-webpack/src/targets/BaseTarget.ts
@@ -123,10 +123,12 @@ function configureDevelopmentPlugins(configurator: WebpackConfigurator) {
   }
 
   // watch common code
-  let commonSourceDir = configurator.electronWebpackConfiguration.commonSourceDirectory
-  if (commonSourceDir == null) {
+  let commonSourceDir: string
+  if (!configurator.electronWebpackConfiguration.commonSourceDirectory) {
     // not src/common, because it is convenient to just put some code into src to use it
     commonSourceDir = path.join(configurator.projectDir, "src")
+  } else {
+    commonSourceDir = configurator.commonSourceDirectory
   }
 
   const alienSourceDir = configurator.getSourceDirectory(configurator.type === "main" ? "renderer" : "main")


### PR DESCRIPTION
This fixes at least one of the issues in #84 that was affecting my project—the `WatchFilterPlugin` is set up to rely on absolute paths in order to behave as expected, and this breaks HMR when `commonSourceDirectory` is specified at all.

Note: I have a setup that looks like this (common when using Lerna/Yarn workspaces in a monorepo):

```
project/
└── packages
    ├── common-lib-1
    ├── common-lib-2
    ├── electron-app-1
    └── electron-app-2
```

In this case, I actually want my `commonSourceDirectory` to be `".."` (I'm running `electron-webpack` out of e.g. `project/packages/electron-app1`), which fully breaks HMR. I considered adding a new config option like `watchDirectories: string[]` and changing the logic to not overload the meaning of `commonSourceDirectory`, but I think this is clean enough for all the use cases I can think of. @develar, please LMK if you prefer something else!