### PR TITLE
Implement dotenv-expand

### DIFF
--- a/packages/electron-webpack/package.json
+++ b/packages/electron-webpack/package.json
@@ -29,6 +29,7 @@
     "css-loader": "^1.0.1",
     "debug": "^4.1.0",
     "dotenv": "^6.1.0",
+    "dotenv-expand": "^4.2.0",
     "electron-devtools-installer": "^2.2.4",
     "electron-webpack-js": "~2.3.0",
     "file-loader": "^2.0.0",

--- a/packages/electron-webpack/src/main.ts
+++ b/packages/electron-webpack/src/main.ts
@@ -1,5 +1,6 @@
 import BluebirdPromise from "bluebird-lst"
 import { config as dotEnvConfig } from "dotenv"
+import dotEnvExpand from "dotenv-expand"
 import { pathExists, readJson } from "fs-extra-p"
 import { Lazy } from "lazy-val"
 import * as path from "path"
@@ -343,9 +344,11 @@ export async function configure(type: ConfigurationType, env: ConfigurationEnv |
   for (const file of dotenvFiles) {
     const exists = await pathExists(file)
     if (exists) {
-      dotEnvConfig({
-        path: file
-      })
+      dotEnvExpand(
+        dotEnvConfig({
+          path: file
+        })
+      )
     }
   }
   return await configurator.configure()


### PR DESCRIPTION
This allows us to expand env variables into dotenv files.For example, to get read the environment variable npm_package_version