### PR TITLE
Added a `staticSourceDirectory` configuration option

### DIFF
--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -8,6 +8,7 @@ Configurations can be applied in `package.json` at `electronWebpack` or in a sep
 ```json
 "electronWebpack": {
   "commonSourceDirectory": "src/common",
+  "staticSourceDirectory": "src/static",
   "title": true,
   "whiteListedModules": ["foo-ui-library"],
 
@@ -35,6 +36,7 @@ Defines the path to a process's or common usage directory, relative to the proje
 ```json
 "electronWebpack": {
   "commonSourceDirectory": "src/common",
+  "staticSourceDirectory": "src/static",
   "main": {
     "sourceDirectory": "src/main"
   },

--- a/packages/electron-webpack/src/config.ts
+++ b/packages/electron-webpack/src/config.ts
@@ -19,7 +19,7 @@ export function getDefaultRelativeSystemDependentCommonSource(): string {
 }
 
 /**
- * Return configuration with resolved commonDistDirectory / commonSourceDirectory.
+ * Return configuration with resolved staticSourceDirectory / commonDistDirectory / commonSourceDirectory.
  */
 export async function getElectronWebpackConfiguration(context: ConfigurationRequest): Promise<ElectronWebpackConfiguration> {
   const result = await getConfig({
@@ -29,6 +29,9 @@ export async function getElectronWebpackConfiguration(context: ConfigurationRequ
     packageMetadata: context.packageMetadata
   })
   const configuration: ElectronWebpackConfiguration = result == null || result.result == null ? {} : result.result
+  if (configuration.staticSourceDirectory == null) {
+    configuration.staticSourceDirectory = "static"
+  }
   if (configuration.commonDistDirectory == null) {
     configuration.commonDistDirectory = "dist"
   }

--- a/packages/electron-webpack/src/core.ts
+++ b/packages/electron-webpack/src/core.ts
@@ -15,6 +15,7 @@ export interface ElectronWebpackConfiguration {
   renderer?: ElectronWebpackConfigurationRenderer | null
   main?: ElectronWebpackConfigurationMain | null
 
+  staticSourceDirectory?: string | null
   commonSourceDirectory?: string | null
   commonDistDirectory?: string | null
 

--- a/packages/electron-webpack/src/electron-builder.ts
+++ b/packages/electron-webpack/src/electron-builder.ts
@@ -30,8 +30,8 @@ export default async function(context: Context) {
     ],
     extraResources: [
       {
-        from: "static",
-        to: "static"
+        from: electronWebpackConfig.staticSourceDirectory,
+        to: electronWebpackConfig.staticSourceDirectory
       }
     ]
   }

--- a/packages/electron-webpack/src/main.ts
+++ b/packages/electron-webpack/src/main.ts
@@ -60,6 +60,7 @@ export class WebpackConfigurator {
   readonly isTest = this.type === "test"
 
   readonly sourceDir: string
+  readonly staticSourceDirectory: string
   readonly commonSourceDirectory: string
   readonly commonDistDirectory: string
 
@@ -104,6 +105,7 @@ export class WebpackConfigurator {
 
     this.sourceDir = this.getSourceDirectory(this.type)!!
 
+    this.staticSourceDirectory = this.electronWebpackConfiguration.staticSourceDirectory!!
     this.commonSourceDirectory = this.electronWebpackConfiguration.commonSourceDirectory!!
     this.commonDistDirectory = this.electronWebpackConfiguration.commonDistDirectory!!
   }

--- a/packages/electron-webpack/src/targets/BaseTarget.ts
+++ b/packages/electron-webpack/src/targets/BaseTarget.ts
@@ -108,7 +108,7 @@ function configureDevelopmentPlugins(configurator: WebpackConfigurator) {
   const plugins = configurator.plugins
   configurator.config.optimization!!.namedModules = true
   plugins.push(new DefinePlugin({
-    __static: `"${path.join(configurator.projectDir, "static").replace(/\\/g, "\\\\")}"`
+    __static: `"${path.join(configurator.projectDir, configurator.staticSourceDirectory).replace(/\\/g, "\\\\")}"`
   }))
 
   plugins.push(new HotModuleReplacementPlugin())

--- a/packages/electron-webpack/src/targets/MainTarget.ts
+++ b/packages/electron-webpack/src/targets/MainTarget.ts
@@ -29,7 +29,7 @@ export class MainTarget extends BaseTarget {
 
     if (configurator.isProduction) {
       configurator.plugins.push(new DefinePlugin({
-        __static: `process.resourcesPath + "/static"`
+        __static: `process.resourcesPath + "/${configurator.staticSourceDirectory}"`
       }))
 
       // do not add for main dev (to avoid adding to hot update chunks), our main-hmr install it

--- a/packages/electron-webpack/src/targets/RendererTarget.ts
+++ b/packages/electron-webpack/src/targets/RendererTarget.ts
@@ -117,11 +117,11 @@ export class RendererTarget extends BaseRendererTarget {
 
     if (configurator.isProduction) {
       configurator.plugins.push(new DefinePlugin({
-        __static: `process.resourcesPath + "/static"`
+        __static: `process.resourcesPath + "/${configurator.staticSourceDirectory}"`
       }))
     }
     else {
-      const contentBase = [path.join(configurator.projectDir, "static"), path.join(configurator.commonDistDirectory, "renderer-dll")];
+      const contentBase = [path.join(configurator.projectDir, configurator.staticSourceDirectory), path.join(configurator.commonDistDirectory, "renderer-dll")];
       (configurator.config as any).devServer = {
         contentBase,
         host: process.env.ELECTRON_WEBPACK_WDS_HOST || "localhost",


### PR DESCRIPTION
Closes https://github.com/electron-userland/electron-webpack/issues/194.

I've tested it both in development and production mode and it works. I've updated the docs as well.

I had a few problems that I encountered while making this:

1. This line caused a compilation error for me, I've just removed `__webpack_hash__` while developing this PR:

https://github.com/fabiospampinato/electron-webpack/blob/a3fd9a640bb857140ba71629ad1cee565b4b88ca/packages/electron-webpack/src/electron-main-hmr/main-hmr.ts#L12

2. Just linking the packages with `yarn link` and `yarn link electron-webpack` to my test app wasn't enough as `electron-webpack` couldn't find some packages.

3. I've never seen double exclamation marks used like this: `this._electronVersion!!`, strange

@develar Let me know if you need any other changes, thank you.