### PR TITLE
Ensuring `react` and `react-dom` are not included as external dependencies

### DIFF
--- a/packages/electron-webpack/src/main.ts
+++ b/packages/electron-webpack/src/main.ts
@@ -257,6 +257,8 @@ export class WebpackConfigurator {
   private computeExternals() {
     const whiteListedModules = new Set(this.electronWebpackConfiguration.whiteListedModules || [])
     if (this.isRenderer) {
+      whiteListedModules.add("react")
+      whiteListedModules.add("react-dom")
       whiteListedModules.add("vue")
     }
 


### PR DESCRIPTION
Closes #244.