### PR TITLE
Support function as custom webpack config

### DIFF
--- a/packages/electron-webpack/src/main.ts
+++ b/packages/electron-webpack/src/main.ts
@@ -235,23 +235,36 @@ export class WebpackConfigurator {
       }
     }
 
-    this.applyCustomModifications()
+    this._configuration = await this.applyCustomModifications(this.config)
 
     return this.config
   }
 
-  private applyCustomModifications() {
-    if (this.type === "renderer" && this.electronWebpackConfiguration.renderer && this.electronWebpackConfiguration.renderer.webpackConfig) {
-      this._configuration = merge.smart(this._configuration as any, require(path.join(this.projectDir, this.electronWebpackConfiguration.renderer.webpackConfig))) as any
+  private applyCustomModifications(config: Configuration): Configuration {
+    const { renderer, main } = this.electronWebpackConfiguration
+
+    const applyCustom = (configPath: string) => {
+      const customModule = require(path.join(this.projectDir, configPath))
+      if (typeof customModule === "function") {
+        return customModule(config)
+      } else {
+        return merge.smart(config, customModule)
+      }
     }
 
-    if (this.type === "renderer-dll" && this.electronWebpackConfiguration.renderer && this.electronWebpackConfiguration.renderer.webpackDllConfig) {
-      this._configuration = merge.smart(this._configuration as any, require(path.join(this.projectDir, this.electronWebpackConfiguration.renderer.webpackDllConfig))) as any
+    if (this.type === "renderer" && renderer && renderer.webpackConfig) {
+      return applyCustom(renderer.webpackConfig)
     }
 
-    if (this.type === "main" && this.electronWebpackConfiguration.main && this.electronWebpackConfiguration.main.webpackConfig) {
-      this._configuration = merge.smart(this._configuration as any, require(path.join(this.projectDir, this.electronWebpackConfiguration.main.webpackConfig))) as any
+    if (this.type === "renderer-dll" && renderer && renderer.webpackDllConfig) {
+      return applyCustom(renderer.webpackDllConfig)
     }
+
+    if (this.type === "main" && main && main.webpackConfig) {
+      return applyCustom(main.webpackConfig)
+    }
+
+    return config
   }
 
   private computeExternals() {


### PR DESCRIPTION
Basically #93 again, because I need it for the same reasons as the original author (don't know why he closed it himself). It allows setting a function as the custom webpack config, which will return the full config, bypassing smart merge altogether (users can merge as they please in this function with the already defined config).

This allows e.g. deleting and modifying existing rules and settings (you might for example need fully custom (S)CSS handling, but you don't need to throw all the other stuff away).