### PR TITLE
Added a “renderer.template” option

### DIFF
--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -20,6 +20,7 @@ Configurations can be applied in `package.json` at `electronWebpack` or in a sep
   "renderer": {
     "dll": ["fooModule"],
     "sourceDirectory": "src/renderer",
+    "template": "src/renderer/index.html",
     "webpackConfig": "custom.webpack.additions.js",
     "webpackDllConfig": "custom.webpackDll.additions.js"
   }

--- a/packages/electron-webpack/src/core.ts
+++ b/packages/electron-webpack/src/core.ts
@@ -33,6 +33,7 @@ export interface ElectronWebpackConfigurationRenderer extends PartConfiguration 
   dll?: Array<string> | { [key: string]: any } | null
   webpackConfig?: string | null
   webpackDllConfig?: string | null
+  template?: string | null
 }
 
 export interface ElectronWebpackConfigurationMain extends PartConfiguration {

--- a/packages/electron-webpack/src/main.ts
+++ b/packages/electron-webpack/src/main.ts
@@ -64,6 +64,8 @@ export class WebpackConfigurator {
   readonly commonSourceDirectory: string
   readonly commonDistDirectory: string
 
+  readonly rendererTemplate: string
+
   readonly debug = _debug(`electron-webpack:${this.type}`)
 
   private _configuration: Configuration | null = null
@@ -107,6 +109,8 @@ export class WebpackConfigurator {
 
     this.commonSourceDirectory = this.electronWebpackConfiguration.commonSourceDirectory!!
     this.commonDistDirectory = this.electronWebpackConfiguration.commonDistDirectory!!
+
+    this.rendererTemplate = ( this.electronWebpackConfiguration.renderer && this.electronWebpackConfiguration.renderer.template ) || 'src/index.ejs';
   }
 
   /**

--- a/packages/electron-webpack/src/targets/RendererTarget.ts
+++ b/packages/electron-webpack/src/targets/RendererTarget.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import { outputFile } from "fs-extra-p"
 import { Lazy } from "lazy-val"
 import * as path from "path"
@@ -97,13 +98,20 @@ export class RendererTarget extends BaseRendererTarget {
 
   async configurePlugins(configurator: WebpackConfigurator): Promise<void> {
     // not configurable for now, as in the electron-vue
-    const customTemplateFile = path.join(configurator.projectDir, "src/index.ejs")
+    const customTemplateFile = path.join(configurator.projectDir, configurator.rendererTemplate)
     const HtmlWebpackPlugin = require("html-webpack-plugin")
     const nodeModulePath = configurator.isProduction ? null : path.resolve(require.resolve("electron"), "..", "..")
 
+    let template;
+    if (await statOrNull(customTemplateFile)) {
+      template = fs.readFileSync(customTemplateFile, {encoding: 'utf8'})
+    } else {
+      template = getDefaultIndexTemplate()
+    }
+
     configurator.plugins.push(new HtmlWebpackPlugin({
       filename: "index.html",
-      template: (await statOrNull(customTemplateFile)) == null ? (await generateIndexFile(configurator, nodeModulePath)) : customTemplateFile,
+      template: await generateIndexFile(configurator, nodeModulePath, template),
       minify: false,
       nodeModules: nodeModulePath
     }))
@@ -157,7 +165,19 @@ async function computeTitle(configurator: WebpackConfigurator): Promise<string |
   return title
 }
 
-async function generateIndexFile(configurator: WebpackConfigurator, nodeModulePath: string | null) {
+function getDefaultIndexTemplate () {
+  return `<!DOCTYPE html>
+    <html>
+      <head>
+        <meta charset="utf-8">
+      </head>
+      <body>
+        <div id="app"></div>
+      </body>
+    </html>`
+}
+
+async function generateIndexFile(configurator: WebpackConfigurator, nodeModulePath: string | null, template: string) {
   // do not use add-asset-html-webpack-plugin - no need to copy vendor files to output (in dev mode will be served directly, in production copied)
   const assets = await getDllAssets(path.join(configurator.commonDistDirectory, "renderer-dll"), configurator)
   const scripts: Array<string> = []
@@ -173,22 +193,28 @@ async function generateIndexFile(configurator: WebpackConfigurator, nodeModulePa
 
   const title = await computeTitle(configurator)
   const filePath = path.join(configurator.commonDistDirectory, ".renderer-index-template.html")
-  await outputFile(filePath, `<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="utf-8">
-    ${title == null ? "" : `<title>${title}</title>`}
-    <script>
-      ${nodeModulePath == null ? "" : `require("module").globalPaths.push("${nodeModulePath.replace(/\\/g, "/")}")`}
-      require("source-map-support/source-map-support.js").install()
-    </script>
-    ${scripts.join("")}
-  ${css.join("")}
-  </head>
-  <body>
-    <div id="app"></div>
-  </body>
-</html>`)
+
+  let html = template;
+
+  if (title) {
+    html = html.replace('</head>', `<title>${title}</title></head>`);
+  }
+
+  if (nodeModulePath) {
+    html = html.replace('</head>', `<script>require('module').globalPaths.push("${nodeModulePath.replace(/\\/g, '/')}")</script></head>`);
+  }
+
+  html = html.replace('</head>', '<script>require("source-map-support/source-map-support.js").install()</script></head>');
+
+  if (scripts.length) {
+    html = html.replace('</head>', `${scripts.join('')}</head>`);
+  }
+
+  if (css.length) {
+    html = html.replace('</head>', `${css.join('')}</head>`);
+  }
+
+  await outputFile(filePath, html);
 
   return `!!html-loader?minimize=false&url=false!${filePath}`
 }


### PR DESCRIPTION
I've added a template option:

<img width="430" alt="screen shot 2019-01-20 at 21 19 12" src="https://user-images.githubusercontent.com/1812093/51444541-110cd980-1cf9-11e9-9665-65060aba5f57.png">

So now the placement and extension of the template is configurable.

Also the way the custom js/css is added to the template is now general enough that it supports template too, so that we don't have to embed that custom js/css manually into the template.

This feature is pretty important for perceived performance, as I can now show my app's window as soon an possible and render a skeleton of the app rather than just waiting until it's fully loaded.