### PR TITLE
allow configuration of webpack-merge

### DIFF
--- a/packages/electron-webpack/src/core.ts
+++ b/packages/electron-webpack/src/core.ts
@@ -33,6 +33,8 @@ export interface ElectronWebpackConfigurationRenderer extends PartConfiguration 
   dll?: Array<string> | { [key: string]: any } | null
   webpackConfig?: string | null
   webpackDllConfig?: string | null
+  mergeFunction?: string | null
+  mergeDllFunction?: string | null
 }
 
 export interface ElectronWebpackConfigurationMain extends PartConfiguration {
@@ -41,6 +43,7 @@ export interface ElectronWebpackConfigurationMain extends PartConfiguration {
    */
   extraEntries?: Array<string> | { [key: string]: string | Array<string> } | string
   webpackConfig?: string | null
+  mergeFunction?: string | null
 }
 
 export interface ConfigurationEnv {

--- a/packages/electron-webpack/src/main.ts
+++ b/packages/electron-webpack/src/main.ts
@@ -244,25 +244,29 @@ export class WebpackConfigurator {
   private applyCustomModifications(config: Configuration): Configuration {
     const { renderer, main } = this.electronWebpackConfiguration
 
-    const applyCustom = (configPath: string) => {
+    const applyCustom = (configPath: string, mergeFunctionPath?: string | null) => {
       const customModule = require(path.join(this.projectDir, configPath))
+
       if (typeof customModule === "function") {
         return customModule(config)
+      } else if (mergeFunctionPath) {
+        const customMergeFunction = require(path.join(this.projectDir, mergeFunctionPath))(merge) as merge.ConfigurationMergeFunction
+        return customMergeFunction(config, customModule)
       } else {
         return merge.smart(config, customModule)
       }
     }
 
     if (this.type === "renderer" && renderer && renderer.webpackConfig) {
-      return applyCustom(renderer.webpackConfig)
+      return applyCustom(renderer.webpackConfig, renderer.mergeFunction)
     }
 
     if (this.type === "renderer-dll" && renderer && renderer.webpackDllConfig) {
-      return applyCustom(renderer.webpackDllConfig)
+      return applyCustom(renderer.webpackDllConfig, renderer.mergeDllFunction)
     }
 
     if (this.type === "main" && main && main.webpackConfig) {
-      return applyCustom(main.webpackConfig)
+      return applyCustom(main.webpackConfig, main.mergeFunction)
     }
 
     return config


### PR DESCRIPTION
I wanted to be able to configure the behaviour of webpack-merge, as per their [docs](https://github.com/survivejs/webpack-merge).

With this PR you may do so as such : 

Create a new .js module in your repository, which exports a function. This function will return a webpack merge function... e.g.

```
// ..."custom.webpack-merge.js"

module.exports = (merge) => 
    merge.smartStrategy(
        {
            'resolve.extensions': 'replace'
        }
    );
```

Then, in your electron-webpack configuration you specify the path to this file e.g.

```
"renderer": {
      "webpackConfig": "custom.webpack.additions.js",
      "mergeFunction": "custom.webpack-merge.js"
    }
```

This can be applied to the renderer (`renderer.mergeFunction`), the rendererDll (`renderer.mergeDllFunction`) and the main (`main.mergeFunction`)

This will only be applied if a customer "webpackConfig" is supplied.