### PR TITLE
Fix typescript type checker when using Vue

### DIFF
--- a/packages/electron-webpack/src/configurators/ts.ts
+++ b/packages/electron-webpack/src/configurators/ts.ts
@@ -25,6 +25,7 @@ export async function configureTypescript(configurator: WebpackConfigurator) {
 
   // no sense to use fork-ts-checker-webpack-plugin for production build
   if (isTranspileOnly && !configurator.isTest) {
+    const hasVue = configurator.hasDependency("vue")
     const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin")
     configurator.plugins.push(new ForkTsCheckerWebpackPlugin({
       tsconfig: tsConfigFile,
@@ -35,7 +36,8 @@ export async function configureTypescript(configurator: WebpackConfigurator) {
 
         warn: console.warn.bind(console),
         error: console.error.bind(console),
-      }
+      },
+      vue: hasVue
     }))
   }
 


### PR DESCRIPTION
Vue support needs to be explicitly enabled in fork-ts-checker-webpack-plugin for type checking to occur so this PR enables that option if Vue is installed as a dependency.
https://github.com/Realytics/fork-ts-checker-webpack-plugin#vue