### PR TITLE
feat: disable hard-coded sourcemap support via environment variable

### DIFF
--- a/packages/electron-webpack/src/targets/RendererTarget.ts
+++ b/packages/electron-webpack/src/targets/RendererTarget.ts
@@ -203,7 +203,9 @@ async function generateIndexFile(configurator: WebpackConfigurator, nodeModulePa
     html = html.replace("</head>", `<script>require('module').globalPaths.push("${nodeModulePath.replace(/\\/g, "/")}")</script></head>`)
   }
 
-  html = html.replace("</head>", '<script>require("source-map-support/source-map-support.js").install()</script></head>')
+  if (process.env.ELECTRON_WEBPACK_DISABLE_SOURCE_MAP_SUPPORT) {
+    html = html.replace("</head>", '<script>require("source-map-support/source-map-support.js").install()</script></head>');
+  }
 
   if (scripts.length) {
     html = html.replace("</head>", `${scripts.join("")}</head>`)


### PR DESCRIPTION
In reference to [#285][1], this allows users to disable the hard-coded insertion of a script tag that is inserted into the generated root HTML page, by passing setting the environment variable `ELECTRON_WEBPACK_DISABLE_SOURCE_MAP_SUPPORT` to any non-empty value.

[1]: https://github.com/electron-userland/electron-webpack/issues/285